### PR TITLE
fix for scss build error

### DIFF
--- a/assets/scss/material-dashboard/_sidebar-and-main-panel.scss
+++ b/assets/scss/material-dashboard/_sidebar-and-main-panel.scss
@@ -21,7 +21,7 @@
       margin-left: 2px;
       vertical-align: middle;
       border-top: 4px dashed;
-      border-top: 4px solid\9;
+      border-top: 4px solid;
       border-right: 4px solid transparent;
       border-left: 4px solid transparent;
     }


### PR DESCRIPTION
error detail:
```
ERROR in ./resources/sass/style.scss
Module build failed (from ./node_modules/css-loader/index.js):
ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):
SyntaxError

(24:6) Missed semicolon

  22 |       vertical-align: middle;
  23 |       border-top: 4px dashed;
> 24 |       border-top: 4px solid\9;
     |      ^
  25 |       border-right: 4px solid transparent;
  26 |       border-left: 4px solid transparent;
```