### PR TITLE
Solve Safari button display issues

### DIFF
--- a/assets/css/material-dashboard.css
+++ b/assets/css/material-dashboard.css
@@ -12622,7 +12622,8 @@ textarea.form-control-lg {
 
 .btn-primary,
 .btn.bg-gradient-primary {
-  box-shadow: 0 3px 3px 0 rgba(233, 30, 99, 0.15), 0 3px 1px -2px rgba(233, 30, 99, 0.2), 0 1px 5px 0 rgba(233, 30, 99, 0.15); }
+  box-shadow: 0 3px 3px 0 rgba(233, 30, 99, 0.15), 0 3px 1px -2px rgba(233, 30, 99, 0.2), 0 1px 5px 0 rgba(233, 30, 99, 0.15);
+  -webkit-appearance: none; }
   .btn-primary:hover,
   .btn.bg-gradient-primary:hover {
     background-color: #e91e63;


### PR DESCRIPTION
By adding `-webkit-appearance: none;`, the Safari missing-background issue is now fixed. See #177