### PR TITLE
Update _misc.scss and material-dashboard.css

### DIFF
--- a/assets/css/material-dashboard.css
+++ b/assets/css/material-dashboard.css
@@ -23434,7 +23434,7 @@ hr.horizontal.gray-light {
 .bullets ul {
   display: flex;
   flex-direction: column;
-  align-items: end;
+  align-items: flex-end;
   list-style-type: none;
   margin-right: -1rem;
 }

--- a/assets/scss/material-dashboard/_misc.scss
+++ b/assets/scss/material-dashboard/_misc.scss
@@ -417,7 +417,7 @@ hr.horizontal {
 .bullets ul {
   display: flex;
   flex-direction: column;
-  align-items: end;
+  align-items: flex-end;
   list-style-type: none;
   margin-right: -1rem;
 }


### PR DESCRIPTION
Hi,
I've refactored _misc.scss and material-dashboard.css because of "end value has mixed support, consider using flex-end instead"

I replaced `align-items: end;` with `align-items: flex-end;`

And thanks a lot for your nice dashboard.